### PR TITLE
Feature/noa/soft alignment task

### DIFF
--- a/ik/ik/common.hpp
+++ b/ik/ik/common.hpp
@@ -55,6 +55,36 @@ inline void apply_joint_clipping(const model_t &model, vector_t &q) {
         model.upperPositionLimit.cwiseMin(q.cwiseMax(model.lowerPositionLimit));
 }
 
+inline void compute_huber_loss_with_deadband(double raw_error, 
+                                             double huber_threshold, 
+                                             double deadband_threshold, 
+                                             vector_ref_t e, 
+                                             double &scale_factor_result) {
+    // deadzone + Huber-like shaping with continuity
+    if (raw_error <= deadband_threshold)
+    {
+        // fully inactive
+        e << 0.0;
+        scale_factor_result = 0.0;
+    }
+    else if (raw_error <= huber_threshold)
+    {
+        // quadratic region, shifted to start at dead_raw_
+        const double x = raw_error - deadband_threshold;
+        const double R = huber_threshold - deadband_threshold;
+        e << 0.5 * (x * x) / R;
+        scale_factor_result = x / R;
+    }
+    else
+    {
+        // linear region: ensure continuity with quadratic at huber_raw_
+        const double x = raw_error - huber_threshold;
+        const double base = 0.5 * (huber_threshold - deadband_threshold);
+        e << base + x;
+        scale_factor_result = 1.0;
+    }
+}
+
 // Default solver parameters
 struct default_solver_parameters {
     // Maximum number of iterations to perform

--- a/ik/ik/frame.hpp
+++ b/ik/ik/frame.hpp
@@ -284,8 +284,8 @@ enum class AlignAxisType { AxisX = 0, AxisY = 1, AxisZ = 2 };
             set_dead_and_huber_degrees(deadband_deg, huber_deg);
         }
 
-        /**
-         * @brief Computes the task error between the current and target frame
+    /**
+    * @brief Computes the task error between the current and target frame
      * configurations.
      */
     void compute_error(const model_t &model, data_t &data,
@@ -304,30 +304,9 @@ enum class AlignAxisType { AxisX = 0, AxisY = 1, AxisZ = 2 };
 
             const double dot_rt = r.dot(target.normalized());
             const double raw_error = 1.0 - dot_rt; // in [0, 2]
-
-            // deadzone + Huber-like shaping with continuity
-            if (raw_error <= dead_raw_)
-                {
-                // fully inactive
-                e << 0.0;
-                scale_factor_ = 0.0;
-            }
-            else if (raw_error <= huber_raw_)
-            {
-                // quadratic region, shifted to start at dead_raw_
-                const double x = raw_error - dead_raw_;
-                const double R = huber_raw_ - dead_raw_;
-                e << 0.5 * (x * x) / R;
-                scale_factor_ = x / R;
-            }
-            else
-            {
-                // linear region: ensure continuity with quadratic at huber_raw_
-                const double x = raw_error - huber_raw_;
-                const double base = 0.5 * (huber_raw_ - dead_raw_);
-                e << base + x;
-                scale_factor_ = 1.0;
-            }
+            
+            //Modifies e & scale_factor
+            compute_huber_loss_with_deadband(raw_error, huber_raw_, dead_raw_, e, scale_factor_);
     }
 
     /**
@@ -350,12 +329,10 @@ enum class AlignAxisType { AxisX = 0, AxisY = 1, AxisZ = 2 };
             const vector3_t tnorm = target.normalized();
             Eigen::RowVector3d rot_term = -(axis_vec.cross(tnorm)).transpose(); // 1x3
 
-            if (scale_factor_ <= 0.0)
-            {
+            if (scale_factor_ <= 0.0) {
                 jac.setZero();
-                }
-                else
-                {
+            }
+            else {
                 jac = scale_factor_ * rot_term * (rMf.rotation() * frame_jacobian_.bottomRows(3));
             }
     }

--- a/ik/ik/frame.hpp
+++ b/ik/ik/frame.hpp
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <cmath> // cos, M_PI
 #include <pinocchio/algorithm/frames.hpp>
 
 #include "ik/constraint.hpp"
@@ -225,11 +225,11 @@ enum class AlignAxisType { AxisX = 0, AxisY = 1, AxisZ = 2 };
     AlignAxisTask(const model_t &model, const std::string &frame,
                   const AlignAxisType &axis,
                       const std::string &reference_frame = "universe",
-                      double tolerance = 0.1,
+                      double deadband_deg = 10.0, double huber_deg = 10.0,
                       bool use_soft_alignment = false)
             : Task(), axis_(axis), frame(frame), reference_frame(reference_frame), use_soft_alignment_(use_soft_alignment)
         {
-            this->set_tolerance_degrees(tolerance);
+            this->set_dead_and_huber_degrees(deadband_deg, huber_deg);
         // Set dimension
         this->set_dimension(index_t(1));
         // Initialise frame jacobian matrix
@@ -255,44 +255,36 @@ enum class AlignAxisType { AxisX = 0, AxisY = 1, AxisZ = 2 };
             const model_t &model, const std::string &frame,
             const AlignAxisType &axis,
             const std::string &reference_frame = "universe",
-            double tolerance_degrees = 5.0)
+            double deadband_deg = 10.0, double huber_deg = 10.0)
         {
             return std::make_shared<AlignAxisTask>(model, frame, axis,
-                                                   reference_frame, tolerance_degrees, true);
+                                                   reference_frame, deadband_deg, huber_deg, true);
         }
 
-        /**
-         * @brief Set soft alignment tolerance in degrees
-         *
-         * @param degrees Misalignment angle in degrees at which the error transitions
-         *        from quadratic to linear behavior
-         */
-        void set_tolerance_degrees(double degrees)
+        // call this once to configure tolerances
+        void set_dead_and_huber_degrees(double dead_deg, double huber_deg)
         {
-            double radians = degrees * M_PI / 180.0;
-            tolerance_ = 1.0 - std::cos(radians);
-        }
+            double dead_rad = dead_deg * M_PI / 180.0;
+            double huber_rad = huber_deg * M_PI / 180.0;
+            dead_raw_ = 1.0 - std::cos(dead_rad);
+            huber_raw_ = 1.0 - std::cos(huber_rad);
 
-        /**
-         * @brief Get current tolerance as degrees
-         *
-         * @return Misalignment angle in degrees
-         */
-        double get_tolerance_degrees() const
-        {
-            return std::acos(1.0 - tolerance_) * 180.0 / M_PI;
+            if (huber_raw_ <= dead_raw_)
+            {
+                // enforce huber > dead
+                huber_raw_ = dead_raw_ + 1e-6;
+            }
         }
 
         /**
          * @brief Enable/disable soft alignment behavior
          *
          * @param enable True to enable soft alignment, false for original behavior
-         * @param tolerance Threshold for quadratic-to-linear transition
          */
-        void set_soft_alignment(bool enable, double tolerance = 0.1)
+        void set_soft_alignment(bool enable, double deadband_deg = 10.0, double huber_deg = 10.0)
         {
             use_soft_alignment_ = enable;
-            tolerance_ = tolerance;
+            set_dead_and_huber_degrees(deadband_deg, huber_deg);
         }
 
         /**
@@ -310,24 +302,35 @@ enum class AlignAxisType { AxisX = 0, AxisY = 1, AxisZ = 2 };
         Eigen::Ref<const vector3_t> r =
             rMf.rotation().col(static_cast<Eigen::Index>(axis_));
 
-            double raw_error = 1.0 - r.dot(target.normalized());
+            if (!use_soft_alignment_)
+                return;
 
-            if (use_soft_alignment_)
+            const double dot_rt = r.dot(target.normalized());
+            const double raw_error = 1.0 - dot_rt; // in [0, 2]
+
+            // deadzone + Huber-like shaping with continuity
+            if (raw_error <= dead_raw_)
+                {
+                // fully inactive
+                e << 0.0;
+                scale_factor_ = 0.0;
+            }
+            else if (raw_error <= huber_raw_)
             {
-                // Huber-like shaping
-                if (raw_error <= tolerance_)
-                {
-                    e << 0.5 * raw_error * raw_error / tolerance_; // quadratic region
-                }
-                else
-                {
-                    e << raw_error - 0.5 * tolerance_; // linear region
-                }
+                // quadratic region, shifted to start at dead_raw_
+                const double x = raw_error - dead_raw_;  // in [0, huber_raw_ - dead_raw_]
+                const double R = huber_raw_ - dead_raw_; // positive
+                e << 0.5 * (x * x) / R;                  // 0.5 * x^2 / R
+                // derivative of e wrt raw_error -> x / R
+                scale_factor_ = x / R;
             }
             else
             {
-                // Original behavior
-                e << raw_error;
+                // linear region: ensure continuity with quadratic at huber_raw_
+                const double x = raw_error - huber_raw_;
+                const double base = 0.5 * (huber_raw_ - dead_raw_);
+                e << base + x;       // slope 1 in linear tail
+                scale_factor_ = 1.0; // derivative is 1
             }
     }
 
@@ -344,31 +347,21 @@ enum class AlignAxisType { AxisX = 0, AxisY = 1, AxisZ = 2 };
         pinocchio::getFrameJacobian(model, data, model.getFrameId(frame),
                                     pinocchio::LOCAL, frame_jacobian_);
 
-            Eigen::Ref<const vector3_t> r =
-                rMf.rotation().col(static_cast<Eigen::Index>(axis_));
-            double raw_error = 1.0 - r.dot(target.normalized());
+            // compute the geometric direction term: (axis x target)
+            const auto axis_vec = rMf.rotation().col(static_cast<Eigen::Index>(axis_));
+            if (!use_soft_alignment_)
+                return;
+            const vector3_t tnorm = target.normalized();
+            Eigen::RowVector3d rot_term = -(axis_vec.cross(tnorm)).transpose(); // 1x3
 
-            // Default scaling
-            double scale_factor = 1.0;
-
-            if (use_soft_alignment_)
+            if (scale_factor_ <= 0.0)
             {
-                if (raw_error <= tolerance_)
-                {
-                    scale_factor = raw_error / tolerance_; // derivative of quadratic region
+                jac.setZero();
                 }
                 else
                 {
-                    scale_factor = 1.0; // derivative of linear region
-                }
+                jac = scale_factor_ * rot_term * (rMf.rotation() * frame_jacobian_.bottomRows(3));
             }
-
-            jac = -scale_factor *
-                  (rMf.rotation()
-                    .col(static_cast<Eigen::Index>(axis_))
-                    .cross(target.normalized()))
-                   .transpose() *
-              rMf.rotation() * frame_jacobian_.bottomRows(3);
     }
 
     /**
@@ -389,8 +382,12 @@ enum class AlignAxisType { AxisX = 0, AxisY = 1, AxisZ = 2 };
     data_t::Matrix6x frame_jacobian_;
 
         // Soft alignment parameters
-        double tolerance_;        // Quadratic-to-linear transition
         bool use_soft_alignment_; // Enable soft alignment behavior
+
+        // in class
+        double dead_raw_ = 1e-3;  // raw error for deadzone
+        double huber_raw_ = 0.01; // raw error where quadratic->linear switch happens
+        double scale_factor_ = 1.0;
 };
 
 /**

--- a/ik/ik/frame.hpp
+++ b/ik/ik/frame.hpp
@@ -205,23 +205,31 @@ enum class AlignAxisType { AxisX = 0, AxisY = 1, AxisZ = 2 };
  * @brief Task designed to align a particular axis of an end-effector frame to,
  * irrespective of the other axes of the frame. Appropriate for contact tasks
  * where having the end-effector aligned with the contact normal is essential.
+     * Now includes soft alignment (Huber-style loss) for reduced stiffness.
  *
  */
-class AlignAxisTask : public Task {
+    class AlignAxisTask : public Task
+    {
    public:
     /**
      * @brief Constructor for creating a frame task.
      *
      * @param model The Pinocchio model of the robot.
      * @param frame The name of the frame for which the task is defined.
-     * @param type The type of task (default: `KinematicType::Full`).
+         * @param axis The axis to align.
      * @param reference_frame The name of the reference frame for the task
      * (default: "universe").
+         * @param tolerance Threshold for quadratic-to-linear transition in degrees (default: 0.1).
+         * @param use_soft_alignment Enable soft alignment behavior (default: false for backward compatibility).
      */
     AlignAxisTask(const model_t &model, const std::string &frame,
                   const AlignAxisType &axis,
-                  const std::string &reference_frame = "universe")
-        : Task(), axis_(axis), frame(frame), reference_frame(reference_frame) {
+                      const std::string &reference_frame = "universe",
+                      double tolerance = 0.1,
+                      bool use_soft_alignment = false)
+            : Task(), axis_(axis), frame(frame), reference_frame(reference_frame), use_soft_alignment_(use_soft_alignment)
+        {
+            this->set_tolerance_degrees(tolerance);
         // Set dimension
         this->set_dimension(index_t(1));
         // Initialise frame jacobian matrix
@@ -230,70 +238,133 @@ class AlignAxisTask : public Task {
 
     /**
      * @brief Factory method to create a shared pointer to a frame task.
-     *
-     * @param model The Pinocchio model of the robot.
-     * @param frame The name of the frame for which the task is defined.
-     * @param type The type of task (default: `KinematicType::Full`).
-     * @param reference_frame The name of the reference frame for the task
-     * (default: "universe").
-     * @return A shared pointer to the created `FrameTask` instance.
      */
     static std::shared_ptr<AlignAxisTask> create(
         const model_t &model, const std::string &frame,
         const AlignAxisType &axis,
-        const std::string &reference_frame = "universe") {
+            const std::string &reference_frame = "universe")
+        {
         return std::make_shared<AlignAxisTask>(model, frame, axis,
                                                reference_frame);
     }
 
     /**
-     * @brief Computes the tasj error between the current and target frame
+         * @brief Factory method to create a shared pointer to a soft alignment task.
+         */
+        static std::shared_ptr<AlignAxisTask> create_soft(
+            const model_t &model, const std::string &frame,
+            const AlignAxisType &axis,
+            const std::string &reference_frame = "universe",
+            double tolerance_degrees = 5.0)
+        {
+            return std::make_shared<AlignAxisTask>(model, frame, axis,
+                                                   reference_frame, tolerance_degrees, true);
+        }
+
+        /**
+         * @brief Set soft alignment tolerance in degrees
+         *
+         * @param degrees Misalignment angle in degrees at which the error transitions
+         *        from quadratic to linear behavior
+         */
+        void set_tolerance_degrees(double degrees)
+        {
+            double radians = degrees * M_PI / 180.0;
+            tolerance_ = 1.0 - std::cos(radians);
+        }
+
+        /**
+         * @brief Get current tolerance as degrees
+         *
+         * @return Misalignment angle in degrees
+         */
+        double get_tolerance_degrees() const
+        {
+            return std::acos(1.0 - tolerance_) * 180.0 / M_PI;
+        }
+
+        /**
+         * @brief Enable/disable soft alignment behavior
+         *
+         * @param enable True to enable soft alignment, false for original behavior
+         * @param tolerance Threshold for quadratic-to-linear transition
+         */
+        void set_soft_alignment(bool enable, double tolerance = 0.1)
+        {
+            use_soft_alignment_ = enable;
+            tolerance_ = tolerance;
+        }
+
+        /**
+         * @brief Computes the task error between the current and target frame
      * configurations.
-     *
-     * @param model The Pinocchio model of the robot.
-     * @param data The Pinocchio data structure for the robot.
-     * @param e The vector to store the computed error.
      */
     void compute_error(const model_t &model, data_t &data,
-                       const vector_const_ref_t q, vector_ref_t e) override {
+                           const vector_const_ref_t q, vector_ref_t e) override
+        {
         // Compute the frame error
         const auto &oMf = get_transform_frame_to_world(model, data, frame);
-        // Reference Frame to World
-        const auto &oMr =
-            get_transform_frame_to_world(model, data, reference_frame);
-        // Frame to Reference Frame
+            const auto &oMr = get_transform_frame_to_world(model, data, reference_frame);
         auto rMf = oMr.actInv(oMf);
-        // Get axis of frame with respect to the reference frame
+
         Eigen::Ref<const vector3_t> r =
             rMf.rotation().col(static_cast<Eigen::Index>(axis_));
 
-        // Compute alignment error
-        e << 1.0 - r.dot(target.normalized());
+            double raw_error = 1.0 - r.dot(target.normalized());
+
+            if (use_soft_alignment_)
+            {
+                // Huber-like shaping
+                if (raw_error <= tolerance_)
+                {
+                    e << 0.5 * raw_error * raw_error / tolerance_; // quadratic region
+                }
+                else
+                {
+                    e << raw_error - 0.5 * tolerance_; // linear region
+                }
+            }
+            else
+            {
+                // Original behavior
+                e << raw_error;
+            }
     }
 
     /**
      * @brief Computes the task Jacobian matrix.
-     *
-     * @param model The Pinocchio model of the robot.
-     * @param data The Pinocchio data structure for the robot.
-     * @param jac The matrix to store the computed Jacobian.
      */
     void compute_jacobian(const model_t &model, data_t &data,
-                          matrix_ref_t jac) override {
-        // Compute the frame error
+                              matrix_ref_t jac) override
+        {
         const auto &oMf = get_transform_frame_to_world(model, data, frame);
-        // Reference Frame to World
-        const auto &oMr =
-            get_transform_frame_to_world(model, data, reference_frame);
-        // Frame to Reference Frame
+            const auto &oMr = get_transform_frame_to_world(model, data, reference_frame);
         auto rMf = oMr.actInv(oMf);
 
-        // Compute Jacobian of end-effector in local frame
         pinocchio::getFrameJacobian(model, data, model.getFrameId(frame),
                                     pinocchio::LOCAL, frame_jacobian_);
 
-        // Create task Jacobian
-        jac = -(rMf.rotation()
+            Eigen::Ref<const vector3_t> r =
+                rMf.rotation().col(static_cast<Eigen::Index>(axis_));
+            double raw_error = 1.0 - r.dot(target.normalized());
+
+            // Default scaling
+            double scale_factor = 1.0;
+
+            if (use_soft_alignment_)
+            {
+                if (raw_error <= tolerance_)
+                {
+                    scale_factor = raw_error / tolerance_; // derivative of quadratic region
+                }
+                else
+                {
+                    scale_factor = 1.0; // derivative of linear region
+                }
+            }
+
+            jac = -scale_factor *
+                  (rMf.rotation()
                     .col(static_cast<Eigen::Index>(axis_))
                     .cross(target.normalized()))
                    .transpose() *
@@ -316,6 +387,10 @@ class AlignAxisTask : public Task {
     string_t reference_frame;
     // Matrix to compute the frame jacobians of the task
     data_t::Matrix6x frame_jacobian_;
+
+        // Soft alignment parameters
+        double tolerance_;        // Quadratic-to-linear transition
+        bool use_soft_alignment_; // Enable soft alignment behavior
 };
 
 /**

--- a/ik/ik/frame.hpp
+++ b/ik/ik/frame.hpp
@@ -230,9 +230,7 @@ enum class AlignAxisType { AxisX = 0, AxisY = 1, AxisZ = 2 };
             : Task(), axis_(axis), frame(frame), reference_frame(reference_frame), use_soft_alignment_(use_soft_alignment)
         {
             this->set_dead_and_huber_degrees(deadband_deg, huber_deg);
-        // Set dimension
         this->set_dimension(index_t(1));
-        // Initialise frame jacobian matrix
         frame_jacobian_ = pinocchio::Data::Matrix6x::Zero(6, model.nv);
     }
 
@@ -271,7 +269,6 @@ enum class AlignAxisType { AxisX = 0, AxisY = 1, AxisZ = 2 };
 
             if (huber_raw_ <= dead_raw_)
             {
-                // enforce huber > dead
                 huber_raw_ = dead_raw_ + 1e-6;
             }
         }
@@ -318,10 +315,9 @@ enum class AlignAxisType { AxisX = 0, AxisY = 1, AxisZ = 2 };
             else if (raw_error <= huber_raw_)
             {
                 // quadratic region, shifted to start at dead_raw_
-                const double x = raw_error - dead_raw_;  // in [0, huber_raw_ - dead_raw_]
-                const double R = huber_raw_ - dead_raw_; // positive
-                e << 0.5 * (x * x) / R;                  // 0.5 * x^2 / R
-                // derivative of e wrt raw_error -> x / R
+                const double x = raw_error - dead_raw_;
+                const double R = huber_raw_ - dead_raw_;
+                e << 0.5 * (x * x) / R;
                 scale_factor_ = x / R;
             }
             else
@@ -329,8 +325,8 @@ enum class AlignAxisType { AxisX = 0, AxisY = 1, AxisZ = 2 };
                 // linear region: ensure continuity with quadratic at huber_raw_
                 const double x = raw_error - huber_raw_;
                 const double base = 0.5 * (huber_raw_ - dead_raw_);
-                e << base + x;       // slope 1 in linear tail
-                scale_factor_ = 1.0; // derivative is 1
+                e << base + x;
+                scale_factor_ = 1.0;
             }
     }
 


### PR DESCRIPTION
Adds a soft alignment task - allowing for a no alignment when within the deadband and giving a gentle adjustment (huber) when near alignment tolerance. Essentially factors in magnetos passive gimbal (30 degrees).

Requires:
https://github.com/Nexxis-Technology/magneto_topside/compare/feature/NST-1603-implement-soft-alignment-task-to-inverse-kinematic-solver?expand=1